### PR TITLE
Fixed typo in contacts page.

### DIFF
--- a/bits/allgemeines/ansprechpartner/index.htm
+++ b/bits/allgemeines/ansprechpartner/index.htm
@@ -144,7 +144,7 @@ function MM_swapImage() { //v3.0
   <div class="floatblocks">
     <h2>SCC-Mailhostteam</h2>
     <p>Für Fragen zum Mailsystem<br />
-        E-Mail: <a href="mailto:mailhost-team@scc.kit.edu">KIT-CERT</a><br />
+        E-Mail: <a href="mailto:mailhost-team@scc.kit.edu">Mailhost-Team</a><br />
      </p>
   </div>
   <!-- InstanceEndEditable --></div>


### PR DESCRIPTION
Auf der Kontaktseite stand bei Mailhost-Team noch KIT-CERT.
